### PR TITLE
Move component inputs and outputs from superclass to component class

### DIFF
--- a/common-ux/CHANGELOG.md
+++ b/common-ux/CHANGELOG.md
@@ -1,10 +1,11 @@
 # 1.0.0-rc.2
 
 - (SEMVER-PATCH) Document the currentPresentation grid input
+- (SEMVER-PATCH) Move component inputs and outputs from superclass to component class
 
 # 1.0.0-rc.0
 
-- (SEMVER-MINOR) Add application loading bar 
+- (SEMVER-MINOR) Add application loading bar
 - (SEMVER-MINOR) Single select toggles selection
 - (SEMVER-MINOR) Added the ability to change the presentation of grid data between rows and lists
 - (SEMVER-MINOR) Fix for no rows message not being displayed

--- a/common-ux/components/applicationLoadingBar.ts
+++ b/common-ux/components/applicationLoadingBar.ts
@@ -9,4 +9,3 @@ import {Component} from 'angular2/core';
 })
 export class ApplicationLoadingBar {
 }
-

--- a/common-ux/components/globalContext.ts
+++ b/common-ux/components/globalContext.ts
@@ -1,17 +1,16 @@
 /* Copyright (c) Microsoft Corporation. All Rights Reserved. */
 
-import {Input} from 'angular2/core';
 import {DefaultResources} from './resources';
 
 export class GlobalContext {
-    
+
     /**
      * Resources; see DefaultResources for typings
      * OPTIONAL: if not present, default resources are used
      * NOTE: if you do not provide a specific resource that is expected, fallback to the default resources will occur
      */
-    @Input('resources') Resources = DefaultResources;
-    
+    public Resources = DefaultResources;
+
     /**
      * This is a second reference to the default resources so that if the consumer of the grid provides a resource override, we can still fall back to the default if it isn't present
      */

--- a/common-ux/components/grid.ts
+++ b/common-ux/components/grid.ts
@@ -25,6 +25,11 @@ const arrowsOffset: number = 20;
 export class Grid<T> extends GlobalContext {
 
     /**
+     * Resources; see GlobalContext for more information
+     */
+    @Input('resources') Resources;
+
+    /**
      * This is the source that is passed in; it can be either an array, or a full grid source
      */
     @Input() public source: GridSource<T> | T[];
@@ -52,7 +57,7 @@ export class Grid<T> extends GlobalContext {
      * OPTIONAL: when not present, the checkbox for turning on and off polling is hidden
      */
     @Input() public poll: (shouldPoll?: boolean) => boolean;
-    
+
     /**
      * This is the current presentation
      */
@@ -62,7 +67,7 @@ export class Grid<T> extends GlobalContext {
      * This is the selection changed event that returns the ids of what was selected
      */
     @Output() public selectionChanged: EventEmitter<T[]> = new EventEmitter<T[]>();
-    
+
     /**
      * This occurs when a row is double clicked
      */
@@ -233,7 +238,7 @@ export class Grid<T> extends GlobalContext {
             this.gridSource.filter.next(filter);
         }
     }
-    
+
     /**
      * If we haven't previously sorted the grid, do so here
      */
@@ -398,7 +403,7 @@ export class Grid<T> extends GlobalContext {
         document.body.removeEventListener('mouseup', this.stopColumnResize);
         document.body.classList.remove('resizing-columns');
     };
-    
+
     endResize() {
         setTimeout(() => {
             this.columnResize.startX = 0;
@@ -417,9 +422,9 @@ export class Grid<T> extends GlobalContext {
     }
 
     doubleClickHeader(columnIndex) {
-        this.configuration.columns[columnIndex].width 
-            = this.element.nativeElement.querySelector(`[data-column-header=col${columnIndex}] .content span`).offsetWidth 
-            + doubleCellPadding 
+        this.configuration.columns[columnIndex].width
+            = this.element.nativeElement.querySelector(`[data-column-header=col${columnIndex}] .content span`).offsetWidth
+            + doubleCellPadding
             + arrowsOffset;
         this.updateWidths();
     }
@@ -447,17 +452,17 @@ export class Grid<T> extends GlobalContext {
             return Math.floor(100 / this.configuration.columns.length) + '%';
         }
     }
-    
+
     doubleClickRow(row: T) {
         this.rowDoubleClick.emit(row);
     }
-    
+
     getArrowClass(ascending: boolean, index: number) {
         var column = this.configuration.columns[index];
         var filter = this.gridSource.filter.value;
-        
+
         if (!filter || !filter.sorted) return;
-        
+
         return {
             'current': column.key === filter.sorted.columnKey && filter.sorted.ascending === ascending
         };

--- a/common-ux/components/grid/body/grid.body.ts
+++ b/common-ux/components/grid/body/grid.body.ts
@@ -1,63 +1,64 @@
 /* Copyright (c) Microsoft Corporation. All Rights Reserved. */
 
-import {Output, Input, ViewEncapsulation, ChangeDetectionStrategy, EventEmitter, ChangeDetectorRef, SimpleChange} from 'angular2/core';
+import {ViewEncapsulation, ChangeDetectionStrategy, EventEmitter, ChangeDetectorRef, SimpleChange} from 'angular2/core';
 import {GridConfiguration, SelectionStyle} from '../grid.configuration';
 import {BehaviorSubject, Subscription} from 'rxjs/Rx';
 import {GlobalContext} from '../../globalContext';
 
 export class GridBody<T> extends GlobalContext {
+
     /**
      * Rows
      */
-    @Input() public rows: T[];
+    public rows: T[];
 
     /**
      * Column widths
      */
-    @Input() public widths: string[];
+    public widths: string[];
 
     /**
      * This is the configuration that we use to determine what columns to use
      */
-    @Input() public configuration: GridConfiguration<T>;
+    public configuration: GridConfiguration<T>;
 
     /**
      * This is the configuration that we use to determine what columns to use
      */
-    @Input() public getIdentifier: (T) => string;
+    public getIdentifier: (T) => string;
 
     /**
      * Selected rows
      */
-    @Input() public selectedRows: BehaviorSubject<{ [key: string]: T }>;
+    public selectedRows: BehaviorSubject<{ [key: string]: T }>;
 
     /**
      * This means that there is a performance spy; if so, use the group specified for sub groups for columns
      * OPTIONAL: by default it is null; if the 'spy-performance' attribute is set, then it will enhance the groups with those in the grid
      */
-    @Input('spy-performance') performanceSpyGroup: string = null;
+    public performanceSpyGroup: string = null;
 
     /**
      * This is whether or not to enable performance logging through performance spies
      * OPTIONAL: by default it is true, but spy performance won't be enabled unless the 'spy-performance' attribute is present
      */
-    @Input('spy-performance-enabled') performanceSpyEnabled: boolean = true;
+    public performanceSpyEnabled: boolean = true;
 
     /**
      * This is the selection changed event that returns the ids of what was selected
      */
-    @Output() public selectionChanged: EventEmitter<T[]> = new EventEmitter<T[]>();
-    
+    public selectionChanged: EventEmitter<T[]> = new EventEmitter<T[]>();
+
     /**
      * This is the double click of a row event
      */
-    @Output() public rowDoubleClick: EventEmitter<T> = new EventEmitter<T>();
+    public rowDoubleClick: EventEmitter<T> = new EventEmitter<T>();
 
     /**
      * Subscription to selected rows
      */
     public subscription: Subscription;
-    
+
     /**
      * Timeout used to avoid changing selection on double click
      */
@@ -73,14 +74,14 @@ export class GridBody<T> extends GlobalContext {
                 if (this.subscription) {
                     this.subscription.unsubscribe();
                 }
-                
+
                 this.subscription = this.selectedRows.subscribe(selection => {
                     this.cd.markForCheck(); // forces an update to change detection
                 });
             }
         }
     }
-    
+
     ngOnDestroy() {
         if (this.subscription && !this.subscription.isUnsubscribed) {
             this.subscription.unsubscribe();
@@ -112,7 +113,7 @@ export class GridBody<T> extends GlobalContext {
             this.selectedRows.next(selection);
         });
     }
-    
+
     doubleClickRow(row: T) {
         this.rowDoubleClick.emit(row);
         if (this.clickTimeout) {

--- a/common-ux/components/grid/body/list.ts
+++ b/common-ux/components/grid/body/list.ts
@@ -2,37 +2,63 @@
 
 import {GridBody} from './grid.body';
 import {PerformanceSpy} from '../../performance-spy';
-import {Component, ChangeDetectionStrategy, ViewEncapsulation, ChangeDetectorRef} from 'angular2/core';
+import {Component, ChangeDetectionStrategy, ViewEncapsulation, ChangeDetectorRef, Input} from 'angular2/core';
 
 @Component({
     selector: 'grid-body-list',
     template: require('grid/body/list.html'),
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    directives: [PerformanceSpy]
+    directives: [PerformanceSpy],
+    inputs: [
+        'rows',
+        'widths',
+        'configuration',
+        'getIdentifier',
+        'selectedRows',
+    ],
+    outputs: [
+        'selectionChanged',
+        'rowDoubleClick'
+    ]
 })
 export class ListGridBody<T> extends GridBody<T> {
-    
+
+    /**
+     * Resources; see GlobalContext for more information
+     */
+    @Input('resources') Resources;
+
+    /**
+     * Performance spy; see GridBody for more information
+     */
+    @Input('spy-performance') performanceSpyGroup;
+
+    /**
+     * Whether to enable performance logging; see GridBody for more information
+     */
+    @Input('spy-performance-enabled') performanceSpyEnabled;
+
     /**
      * Expanded rows
      */
     public expandedRows: { [key: string]: T } = {};
-    
+
     constructor(cd: ChangeDetectorRef) {
         super(cd);
     }
-    
+
     toggleExpansion(row: T) {
         this.clickTimeout = setTimeout(() => {
-            
+
             let id = this.getIdentifier(row);
-            
+
             if (this.expandedRows[id] === undefined) {
                 this.expandedRows[id] = row;
             } else {
                 delete this.expandedRows[id];
             }
-            
+
             this.cd.markForCheck();
         });
     }

--- a/common-ux/components/grid/body/rows.ts
+++ b/common-ux/components/grid/body/rows.ts
@@ -2,16 +2,43 @@
 
 import {GridBody} from './grid.body';
 import {PerformanceSpy} from '../../performance-spy';
-import {Component, ChangeDetectionStrategy, ViewEncapsulation, ChangeDetectorRef} from 'angular2/core';
+import {Component, ChangeDetectionStrategy, ViewEncapsulation, ChangeDetectorRef, Input} from 'angular2/core';
 
 @Component({
     selector: 'grid-body-rows',
     template: require('grid/body/rows.html'),
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    directives: [PerformanceSpy]
+    directives: [PerformanceSpy],
+    inputs: [
+        'rows',
+        'widths',
+        'configuration',
+        'getIdentifier',
+        'selectedRows',
+    ],
+    outputs: [
+        'selectionChanged',
+        'rowDoubleClick'
+    ]
 })
 export class RowsGridBody<T> extends GridBody<T> {
+
+    /**
+     * Resources; see GlobalContext for more information
+     */
+    @Input('resources') Resources;
+
+    /**
+     * Performance spy; see GridBody for more information
+     */
+    @Input('spy-performance') performanceSpyGroup;
+
+    /**
+     * Whether to enable performance logging; see GridBody for more information
+     */
+    @Input('spy-performance-enabled') performanceSpyEnabled;
+
     constructor(cd: ChangeDetectorRef) {
         super(cd);
     }


### PR DESCRIPTION
This should work around the problems described in the following issues whereby inputs and outputs declared on a parent class are not always respected by a child component:

 * https://github.com/angular/angular/issues/5415
 * https://github.com/angular/angular/issues/8596
 * https://github.com/angular/angular/issues/7191

Due to issues with Webpack build on my machine, I am unable to personally verify that this fix works, just that it follows the pattern of the workarounds described in the issues above.