### PR TITLE
Put the full URL of the current page in the session returnTo value

### DIFF
--- a/authentication/.npmignore
+++ b/authentication/.npmignore
@@ -2,10 +2,6 @@
 /node_modules/
 /typings/
 
-# Unnecessary built files
-*.tgz
-*.js.map
-
 # Source files
 *.ts
 !*.d.ts

--- a/authentication/package.json
+++ b/authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-iot/authentication",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "Provides Authentication support for Azure IOT microservices",
   "main": "src/authentication.js",
   "typings": "src/authentication.d.ts",

--- a/authentication/src/authentication.ts
+++ b/authentication/src/authentication.ts
@@ -91,8 +91,12 @@ export class Authentication {
         app.use(passport.session());
         
         const ensureAuthenticated = (req: express.Request, res: express.Response, next) => {
-            if (!req.isAuthenticated()) {            
-                req.session['returnTo'] = req.originalUrl || req.url;
+            if (!req.isAuthenticated()) {    
+                // construct the current URL. Our services run on different 
+                // ports right now, so we need to preserve the full URL with
+                // possible nonstandard ports, which only the http host header
+                // provides. 
+                req.session['returnTo'] = `${req.protocol}://${req.get('host')}${req.originalUrl || req.url}`;
                 res.redirect(loginUrl);
             } else { 
                 next(); 


### PR DESCRIPTION
Change the auth middleware to construct the full URL (protocol+host+
port+path) and store it in the session[returnTo] value, so the login
page can return back to the current page correctly, even if it's
running under a different domain/port.